### PR TITLE
DP-529 comment out constant install of spawner app

### DIFF
--- a/scripts/base/movai-entrypoint.sh
+++ b/scripts/base/movai-entrypoint.sh
@@ -27,11 +27,11 @@ for ppa_env in dev testing main; do
     sudo add-apt-repository -r "deb https://artifacts.cloud.mov.ai/repository/ppa-${ppa_env} ${ppa_env} main"
 done || true
 # isnt this repeated with the previous iteration ?
-#sudo add-apt-repository "deb [arch=all] https://artifacts.cloud.mov.ai/repository/ppa-$MOVAI_PPA $MOVAI_PPA main"
+sudo add-apt-repository "deb [arch=all] https://artifacts.cloud.mov.ai/repository/ppa-$MOVAI_PPA $MOVAI_PPA main"
 
 # movai-spawner installing itself constantly is questionable 
 # and its causing conflicts with movai-service commands on spawner to do apt related operations
-#sudo apt-get -y --no-install-recommends install movai-spawner --reinstall
+sudo apt-get -y --no-install-recommends install movai-spawner --reinstall
 #sudo apt-get clean -y > /dev/null
 
 export PATH=${MOVAI_HOME}/.local/bin:${PATH}


### PR DESCRIPTION
Comment out apt commands in movai-entrypoint for 2 reasons:
- Its questionable if on boot it should be constantly installing the spawner app (as 90% of the cases is reinstalling the same plus there are other ways to do it more consciously. We are under the hood bypassing the meaning of the image version.)
- Currently 2 entities are interacting with the containers doing apt commands  (the service and this entrypoint script)  

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
