### PR TITLE
Fix: restore docker build and catkin build

### DIFF
--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -7,6 +7,7 @@ python3-dev
 python3-scipy
 python3-wstool
 python3-catkin-tools
+python3-rospkg
 libopencv-dev
 python3-opencv
 python-dev

--- a/docker/noetic/packages/requirements.txt
+++ b/docker/noetic/packages/requirements.txt
@@ -1,4 +1,3 @@
-rospkg==1.3.0
 empy==3.3.2
 catkin_pkg
 opencv-python==4.5.3.56


### PR DESCRIPTION
## Content
Fix rosdep issues blocking catkin building

--
- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
