### PR TITLE
Fix wrong bash syntax in entrypoint

### DIFF
--- a/scripts/base/movai-entrypoint.sh
+++ b/scripts/base/movai-entrypoint.sh
@@ -36,7 +36,7 @@ export PYTHONPATH=${APP_PATH}:${MOVAI_HOME}/sdk:${PYTHONPATH}
 # If we have a userspace prepare it
 if [ -d "${MOVAI_USERSPACE}" ]; then
     echo "Userspace detected"
-    mkdir -p "${MOVAI_USERSPACE}/{bags,database}"
+    mkdir -p "${MOVAI_USERSPACE}/"{bags,database}
 else
     echo "No userspace detected"
 fi


### PR DESCRIPTION
Fix wrong bash syntax in entrypoint