### PR TITLE
updating the docker to create new spawner image with the latest packages

### DIFF
--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -26,4 +26,4 @@ python3-debian
 # Communication
 libzmq5
 # Main process
-flow-initiator=2.4.0.2
+flow-initiator=2.4.1.2


### PR DESCRIPTION
Need to create a new image for the spawner with the latest version 
that will include the new DAL with the fix 
[bp-887](https://movai.atlassian.net/browse/BP-887): Excessive spawner docker logs on restart