### PR TITLE
flow-initiator upgrade from 2.4.1.13 to 2.4.1.15

### DIFF
--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -27,4 +27,4 @@ python3-debian
 libzmq5
 mobros=2.0.0.19
 # Main process
-flow-initiator=2.4.1.13
+flow-initiator=2.4.1.15


### PR DESCRIPTION
flow-initiator updated: 2.4.1.13 -> 2.4.1.15
movai-core-shared updated: 2.4.1.8 => 2.4.1.9
revert [BP-957](https://movai.atlassian.net/browse/BP-957) - removing tags from log message

[BP-957]: https://movai.atlassian.net/browse/BP-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ