### PR TITLE
Mobros marking packages with the right install apt-mark'ing

### DIFF
--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -25,6 +25,6 @@ fakeroot
 python3-debian
 # Communication
 libzmq5
-mobros=2.0.0.20
+mobros=2.0.0.21
 # Main process
 flow-initiator=2.4.1.15

--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -25,6 +25,6 @@ fakeroot
 python3-debian
 # Communication
 libzmq5
-mobros=2.0.0.21
+mobros=2.0.0.22
 # Main process
 flow-initiator=2.4.1.15


### PR DESCRIPTION
Mobros now marks dependencies as auto, and the ones mentioned by the user as hold.
Better dependency tree handling.