### PR TITLE
DP-1116 Mobros marking packages with the right install apt-mark'ing [platform 2.3.0]

### DIFF
--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -25,4 +25,4 @@ fakeroot
 python3-debian
 # Communication
 libzmq5
-mobros=2.0.0.21
+mobros=2.0.0.22

--- a/docker/noetic/packages/packages.apt
+++ b/docker/noetic/packages/packages.apt
@@ -25,4 +25,4 @@ fakeroot
 python3-debian
 # Communication
 libzmq5
-mobros=2.0.0.20
+mobros=2.0.0.21


### PR DESCRIPTION
Mobros now marks dependencies as auto, and the ones mentioned by the user as hold.
Better dependency tree handling.