### PR TITLE
DP-1073 - Bump MOV-AI/.github from 1 to 2 (#69)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,15 +18,13 @@ on:
     types: [released]
 jobs:
   spawner-base-noetic:
-    uses: MOV-AI/.github/.github/workflows/docker-workflow.yml@v1
+    uses: MOV-AI/.github/.github/workflows/docker-workflow.yml@v2
     with:
       docker_file: docker/noetic/Dockerfile
       docker_image: qa/spawner-base-noetic
       public: true
       public_image: ce/spawner-base-noetic
-      github_ref: ${{ github.ref }}
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
-      version: ${GITHUB_REF##*/}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: false
       target: spawner
@@ -36,19 +34,19 @@ jobs:
       registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
       pub_registry_user: ${{ secrets.PORTUS_APP_USER }}
       pub_registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
+      github_registry_user: ${{ secrets.RAISE_BOT_COMMIT_USER }}
+      github_registry_password: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
       snyk_token: ${{ secrets.SNYK_TOKEN }}
 
   spawner-ign-noetic:
-    uses: MOV-AI/.github/.github/workflows/docker-workflow.yml@v1
+    uses: MOV-AI/.github/.github/workflows/docker-workflow.yml@v2
     needs: [ "spawner-base-noetic" ]
     with:
       docker_file: docker/noetic/Dockerfile
       docker_image: qa/spawner-ign-noetic
-      github_ref: ${{ github.ref }}
       public: true
       public_image: ce/spawner-ign-noetic
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
-      version: ${GITHUB_REF##*/}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
       target: spawner-ign
@@ -57,4 +55,6 @@ jobs:
       registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
       pub_registry_user: ${{ secrets.PORTUS_APP_USER }}
       pub_registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
+      github_registry_user: ${{ secrets.RAISE_BOT_COMMIT_USER }}
+      github_registry_password: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
       snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -1,6 +1,6 @@
 # === spawner
 ARG DOCKER_REGISTRY="pubregistry.aws.cloud.mov.ai"
-FROM ${DOCKER_REGISTRY}/ce/movai-base-noetic:v2.4.2 AS spawner
+FROM ${DOCKER_REGISTRY}/ce/movai-base-noetic:v2.4.3 AS spawner
 
 # Labels
 LABEL description="MOV.AI Spawner Base Image"


### PR DESCRIPTION
Bumps MOV-AI/.github from 1 to 2.

Test: https://github.com/MOV-AI/containers-spawner-base/actions/runs/5692821927

---
updated-dependencies:
- dependency-name: MOV-AI/.github dependency-type: direct:production update-type: version-update:semver-major ...



* Update base pipeline version

---------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
