### PR TITLE
DP-1694 - Fix of docs endpoint

### DIFF
--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -80,6 +80,8 @@ RUN curl -fsSL $APT_REPOSITORY/movai-applications/gpg | apt-key add - && \
     # Make sure python3 is the only installed one
     apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends python-is-python3 && \
+    mkdir -p /opt/mov.ai/docs && \
+    chown -R movai:movai /opt/mov.ai/docs && \
     # Clean apt
     apt-get autoremove -y && \
     apt-get clean -y > /dev/null && \


### PR DESCRIPTION
- Set expected permissions on docs volume

How to test:
- on backend repo
```
./py-build.bash
docker build -f docker/noetic/Dockerfile . -t registry.hel.mov.ai/qa/backend-noetic:local
```
- on spawner repo
```
docker build --pull -t registry.hel.mov.ai/qa/spawner-noetic:local -f docker/noetic/Dockerfile --target spawner .
```
- on tugbot2 repo use this image and the script `./build-spawner.bash` to build final spawner image
- on movai-service repo
```
./build_debian.sh jammy
```
- apply robot with local versions of backend and spawner
- start robot 

--------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
